### PR TITLE
wave morphing

### DIFF
--- a/software/TELEXo/CVOutput.cpp
+++ b/software/TELEXo/CVOutput.cpp
@@ -351,7 +351,7 @@ void CVOutput::Sync(){
  * 4 = Noise / Sample-and-Hold
  */
 void CVOutput::SetWaveform(int wave){
-  _oscillator->SetTable(wave);
+  _oscillator->SetWaveform(wave);
 }
 
 /*

--- a/software/TELEXo/Oscillator.h
+++ b/software/TELEXo/Oscillator.h
@@ -13,8 +13,8 @@
 #define TABLERANGEDIV2 256
 #define TABLESIZE 513
 #define TABLECOUNT 3
-#define TABLECOUNTPLUSONE 4
 #define WAVEFORMS 5
+#define MORPHRANGE 1000
 
 #define TABLEBITS 9
 #define REDUCEBITS 23 // 32 - TABLEBITS
@@ -37,7 +37,7 @@ class Oscillator
     void SetLFO(int millihertz);
     void TargetLFO(int millihertz);
 
-    void SetTable(int table);
+    void SetWaveform(int wave);
     void ResetPhase(long polarity);
     void SetWidth(int width);
     void SetRectify(int mode);
@@ -61,7 +61,12 @@ class Oscillator
     
   private:
 
-  int _table = 0;
+  int _wave = 0;
+  int _morphWave = 1;
+  int _morph = 0;
+  int _invMorph = MORPHRANGE;
+  bool _morphing = false;
+  int _morphValue = 0;
 
   float _frequency = 0;
   unsigned long _ulphase = 0;


### PR DESCRIPTION
wave morphing implementation.

- `TO.OSC.WAVE` is used to set the waveform as before but now the parameter doesn't specify the waveform but the position on the waveform continuum. 0/1000/2000 etc represent pure waveforms (what used to be specified as 0/1/2) and values in between determine the morphing between adjacent waves. so 0 will be pure sine, 500 will be halfway between sine and triangle, 1000 is pure triangle etc.

- i thought of mapping the full parameter range to the 5 waveforms but this leaves room for more waveforms in the future. 

- interpolation is disabled when morphing is in effect.

- renamed functions/variables to reflect that they represent all waveforms, not just the ones stored in tables.