### PR TITLE
osc phase offset

### DIFF
--- a/software/TELEXo/CVOutput.cpp
+++ b/software/TELEXo/CVOutput.cpp
@@ -343,6 +343,13 @@ void CVOutput::Sync(){
 }
 
 /*
+ * Set the oscillator phase offset
+ */
+void CVOutput::SetPhaseOffset(int phase){
+  _oscillator->SetPhaseOffset(phase);
+}
+
+/*
  * Selects the oscillator waveform
  * 0 = Sine
  * 1 = Triangle

--- a/software/TELEXo/CVOutput.h
+++ b/software/TELEXo/CVOutput.h
@@ -55,6 +55,7 @@ class CVOutput : public Output
     void SetWidth(int width);
     void SetRectify(int mode);
     void Sync();
+    void SetPhaseOffset(int phase);
     void SetFrequencySlew(int slew, short format);
 
     void SetOscQuantizationScale(int scale);

--- a/software/TELEXo/Oscillator.cpp
+++ b/software/TELEXo/Oscillator.cpp
@@ -27,9 +27,10 @@ float Oscillator::Oscillate() {
 
   // unsigned long automatically wraps
   _ulphase += _ulstep;
+  _actualPhase = _ulphase + (_phaseOffset << PHASEBITS);
 
   // reduce this down to meet the tablesize range
-  _location = _ulphase >> REDUCEBITS;
+  _location = _actualPhase >> REDUCEBITS;
    
   switch(_wave){
     case 0:
@@ -40,7 +41,7 @@ float Oscillator::Oscillate() {
         _lastValue =  tables[_wave][_location];
       } else {  
         // interpolate using some fixed math magic (and a floating point scaler)
-        _lastValue = tables[_wave][_location] + (_ulphase & PHASEMASK) * _phasescale * (tables[_wave][_location + 1] - tables[_wave][_location]);
+        _lastValue = tables[_wave][_location] + (_actualPhase & PHASEMASK) * _phasescale * (tables[_wave][_location + 1] - tables[_wave][_location]);
       }
       break;
     case 3:
@@ -48,9 +49,9 @@ float Oscillator::Oscillate() {
       break;
     case 4:
       // generate a new number if we have flipped
-      if (_ulphase < _oldulphase)
+      if (_actualPhase < _oldPhase)
         _lastValue = random(0, 65536) - 32878.;
-      _oldulphase = _ulphase;
+      _oldPhase = _actualPhase;
       break;
     default:
       _lastValue =  0;
@@ -68,7 +69,7 @@ float Oscillator::Oscillate() {
         _morphValue =  _location < _width ? -32767 : 32767;
         break;
       case 4:
-        if (_ulphase < _oldulphase) _morphValue = random(0, 65536) - 32878.;
+        if (_actualPhase < _oldPhase) _morphValue = random(0, 65536) - 32878.;
         break;
       default:
         _morphValue =  0;
@@ -179,6 +180,10 @@ void Oscillator::ResetPhase(long polarity) {
     _ulphase = 0;
   else
     _ulphase = (unsigned long)peaks[_wave] << REDUCEBITS;
+}
+
+void Oscillator::SetPhaseOffset(int phase) {
+  _phaseOffset = constrain(phase, 0, 16384);
 }
 
 void Oscillator::SetPortamentoMs(unsigned long milliseconds){

--- a/software/TELEXo/Oscillator.h
+++ b/software/TELEXo/Oscillator.h
@@ -16,6 +16,7 @@
 #define WAVEFORMS 5
 #define MORPHRANGE 1000
 
+#define PHASEBITS 18
 #define TABLEBITS 9
 #define REDUCEBITS 23 // 32 - TABLEBITS
 #define PHASEMASK 8388607 // ( 1 << REDUCEBITS ) - 1
@@ -39,6 +40,7 @@ class Oscillator
 
     void SetWaveform(int wave);
     void ResetPhase(long polarity);
+    void SetPhaseOffset(int phase);
     void SetWidth(int width);
     void SetRectify(int mode);
 
@@ -71,7 +73,9 @@ class Oscillator
   float _frequency = 0;
   unsigned long _ulphase = 0;
   unsigned long _ulstep = 0;
-  unsigned long _oldulphase = 0;
+  unsigned long _oldPhase = 0;
+  int _phaseOffset = 0;
+  unsigned long _actualPhase = 0;
 
   int _location;
   float _remainder;

--- a/software/TELEXo/TELEXo.ino
+++ b/software/TELEXo/TELEXo.ino
@@ -343,6 +343,11 @@ void actOnCommand(byte cmd, byte out, int value){
       cvOutputs[targetOutput]->Sync();
       break;
       
+    case TO_OSC_PHASE:
+      // 
+      cvOutputs[targetOutput]->SetPhaseOffset(value);
+      break;
+      
     case TO_OSC_WAVE:
       // 
       cvOutputs[targetOutput]->SetWaveform(value);

--- a/software/TELEXo/telex.h
+++ b/software/TELEXo/telex.h
@@ -72,6 +72,7 @@
 #define TO_OSC_SLEW_S 0x50
 #define TO_OSC_SLEW_M 0x51
 #define TO_OSC_TR_ACT 0x52
+#define TO_OSC_PHASE 0x53
 
 #define TO_ENV_ACT 0x60
 #define TO_ENV_ATT 0x61


### PR DESCRIPTION
TXo - new phase offset setting for oscillator/LFO mode:
- shifts phase by specified offset 0..16384 where 16384 is full cycle
- doing SYNC will reset to the specified offset as well
- controlled by remote command `TO.OSC.PHASE` (requires https://github.com/bpcmusic/teletype/pull/1)